### PR TITLE
Fixed error parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Documentation can be found at [Godoc](https://godoc.org/github.com/cosiner/argv)
 # Example
 ```Go
 func TestArgv(t *testing.T) {
-	args, err := argv.Argv([]rune(" ls   `echo /`   |  wc  -l "), os.Environ(), argv.Run)
+	args, err := argv.Argv([]rune(" ls   `echo /`   |  wc  -l "), argv.ParseEnv(os.Environ()), argv.Run)
 	if err != nil {
 	    t.Fatal(err)
 	}


### PR DESCRIPTION
cannot use os.Environ() (type []string) as type map[string]string in argument to Argv